### PR TITLE
Add `fromPtEtaPhiE` to create Lorentz vectors using E instead of m

### DIFF
--- a/src/LorentzVectorHEP.jl
+++ b/src/LorentzVectorHEP.jl
@@ -7,6 +7,7 @@ export LorentzVectorCyl, LorentzVector
 export px, py, pz, energy, fast_mass, pt, eta, phi, mass
 export deltaphi, deltar, deltaeta
 export ΔR, Δϕ, Δη
+export fromPtEtaPhiE
 
 include("cartesian.jl")
 include("cylindrical.jl")

--- a/src/cylindrical.jl
+++ b/src/cylindrical.jl
@@ -94,3 +94,11 @@ const Δη = deltaeta
 end
 deltar(v1::LorentzVectorCyl, v2::LorentzVectorCyl) = sqrt(deltar2(v1, v2))
 const ΔR = deltar
+
+
+function fromPtEtaPhiE(pt, eta, phi, E) 
+    m2 = E^2 - pt^2 - (sinh(eta) * pt)^2
+    m = sign(m2) * sqrt(abs(m2)) 
+    return LorentzVectorCyl(pt, eta, phi, m) 
+end
+  

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -57,3 +57,9 @@ end
         func(v1) ≈ func(LorentzVector(v1))
     end
 end
+
+@testset "fromPtEtaPhiE" begin
+    v1 = LorentzVectorCyl(1761.65,-2.30322,-2.5127,0.105652) 
+    v2 = fromPtEtaPhiE(v1.pt, v1.eta, v1.phi, energy(v1))
+    @test v1.mass ≈ v2.mass atol=1e-6
+ end


### PR DESCRIPTION
PR as discussed in #2 