### PR TITLE
add StaticArrays extension

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,10 +16,7 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.6'
-          - '1.7'
-          - '1.8'
-          - '1.9'
+          - '1.10'
           - '1' # Leave this line unchanged. '1' will automatically expand to the latest stable 1.x release of Julia.
         os: [ubuntu-latest]
         arch: [x64]

--- a/Project.toml
+++ b/Project.toml
@@ -11,6 +11,7 @@ LorentzVectorHEPStaticArraysExt = "StaticArrays"
 
 [compat]
 julia = "^1.6"
+StaticArrays = "1"
 
 [extras]
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"

--- a/Project.toml
+++ b/Project.toml
@@ -1,14 +1,20 @@
 name = "LorentzVectorHEP"
 uuid = "f612022c-142a-473f-8cfd-a09cf3793c6c"
 authors = ["Jerry Ling <proton@jling.dev> and contributors"]
-version = "0.1.6"
+version = "0.1.7"
 
+[weakdeps]
+StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
+
+[extensions]
+LorentzVectorHEPStaticArraysExt = "StaticArrays"
 
 [compat]
 julia = "^1.6"
 
 [extras]
+StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test"]
+test = ["Test", "StaticArrays"]

--- a/ext/LorentzVectorHEPStaticArraysExt.jl
+++ b/ext/LorentzVectorHEPStaticArraysExt.jl
@@ -1,0 +1,41 @@
+module LorentzVectorHEPStaticArraysExt
+
+using LorentzVectorHEP, StaticArrays
+
+
+function StaticArrays.SArray{I,T}(v::LorentzVector) where {I<:Tuple{4},T}
+    @SVector T[v.t, v.x, v.y, v.z]
+end
+function StaticArrays.SArray{I,T}(v::LorentzVectorCyl) where {I<:Tuple{4},T}
+    @SVector T[v.pt, v.eta, v.phi, v.mass]
+end
+
+#====================================================================================================
+NOTE: confusingly, we *are* allowed to set SArray(v) but *NOT* SVector(v).
+This is because the latter would be a constructor for a singleton array [v]
+====================================================================================================#
+
+for LV ∈ (:LorentzVector, :LorentzVectorCyl)
+    @eval StaticArrays.SArray{I}(v::$LV{T}) where {I<:Tuple{4},T} = SArray{I,T}(v)
+    
+    @eval StaticArrays.SVector{4,T}(v::$LV) where {T} = SArray{Tuple{4},T}(v)
+    @eval StaticArrays.SVector{4}(v::$LV{T}) where {T} = SVector{4,T}(v)
+
+    @eval StaticArrays.SArray(v::$LV) = SVector{4}(v)
+
+    @eval function StaticArrays.StaticArray{I,T}(v::$LV) where {I<:Tuple{4},T}
+        SArray{Tuple{4},T}(v)
+    end
+    @eval function StaticArrays.StaticArray{I}(v::$LV) where {I<:Tuple{4}}
+        SArray{Tuple{4}}(v)
+    end
+    @eval StaticArrays.StaticArray(v::$LV) = SArray(v)
+
+    @eval function LorentzVectorHEP.$LV{T}(v::StaticVector{4}) where {T}
+        $LV(ntuple(j -> convert(T, v[j]), Val(4))...)
+    end
+    @eval LorentzVectorHEP.$LV(v::StaticVector{4}) = $LV{eltype(v)}(v)
+end
+
+
+end

--- a/src/LorentzVectorHEP.jl
+++ b/src/LorentzVectorHEP.jl
@@ -33,7 +33,6 @@ Promoting constructors for LorentzVector{T}.
 LorentzVector(t, x, y, z) = LorentzVector(promote(t, x, y, z)...)
 LorentzVector(t::T, x::T, y::T, z::T) where {T <: Union{Integer, Rational, Irrational}} =
     LorentzVector(float(t), x, y, z)
-    
 
 """
     dot(u, v)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -105,3 +105,5 @@ end
     v2 = fromPtEtaPhiE(v1.pt, v1.eta, v1.phi, energy(v1))
     @test v1.mass ≈ v2.mass atol=1e-6
  end
+
+ include("staticarrays.jl")

--- a/test/staticarrays.jl
+++ b/test/staticarrays.jl
@@ -1,0 +1,29 @@
+using LorentzVectorHEP, StaticArrays
+using Test
+
+@testset "static array conversions" begin
+    for LV ∈ (LorentzVector, LorentzVectorCyl)
+        v1 = LV(5.0, 0.1, 0.2, 0.3)
+    
+        v2 = SArray{Tuple{4}}(v1)
+        @test v2 == [5.0, 0.1, 0.2, 0.3]
+        v3 = StaticArray{Tuple{4}}(v1)
+        @test v3 == [5.0, 0.1, 0.2, 0.3]
+        v4 = SArray(v1)
+        @test v4 == [5.0, 0.1, 0.2, 0.3]
+        v5 = SVector{4}(v1)
+        @test v5 == [5.0, 0.1, 0.2, 0.3]
+    end
+
+    v = LorentzVector(SVector{4}(5.0,0.1,0.2,0.3))
+    @test energy(v) == 5.0
+    @test px(v) == 0.1
+    @test py(v) == 0.2
+    @test pz(v) == 0.3
+
+    v = LorentzVectorCyl(SVector{4}(5.0,0.1,0.2,0.3))
+    @test pt(v) == 5.0
+    @test eta(v) == 0.1
+    @test phi(v) == 0.2
+    @test mass(v) == 0.3
+end


### PR DESCRIPTION
This adds the ability to easily convert to and from StaticArrays.  I think having LorentzVector *not* be `AbstractArray` is good for all sorts of reasons, but it does lock it out of use with all sorts of things.  A particularly major potential pain point is autodiff.  At the risk of self-promotion, there is also [LorentzGroup.jl](https://gitlab.com/ExpandingMan/LorentzGroup.jl) which works on `StaticArray`.

I did most of this before realizing that LorentzVectorsBase was a thing.  The same thing could be done there if this gets rebased.

StaticArrays constructors are extremely confusing, not least because they aren't well documented.  I tried to mostly follow [this](https://juliaarrays.github.io/StaticArrays.jl/stable/api/#Conversions-from-Array), but there are a few weird consequences, in particularly `SVector(v::LorentzVector)` isn't allowed.  I added a note in the extension about this, because if, for example, I were to look back at what I did here two weeks from now I would probably say "what an idiot, I didn't do the most obvious thing which is `SVector(v)`".