### PR TITLE
use dot from LinearAlgebra

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -15,7 +15,7 @@ LorentzVectorHEPStaticArraysExt = "StaticArrays"
 [compat]
 LinearAlgebra = "1"
 StaticArrays = "1"
-julia = "^1.6"
+julia = "1.10"
 
 [extras]
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,10 @@
 name = "LorentzVectorHEP"
 uuid = "f612022c-142a-473f-8cfd-a09cf3793c6c"
 authors = ["Jerry Ling <proton@jling.dev> and contributors"]
-version = "0.1.7"
+version = "0.1.8"
+
+[deps]
+LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 
 [weakdeps]
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
@@ -10,8 +13,9 @@ StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 LorentzVectorHEPStaticArraysExt = "StaticArrays"
 
 [compat]
-julia = "^1.6"
+LinearAlgebra = "1.11.0"
 StaticArrays = "1"
+julia = "^1.6"
 
 [extras]
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"

--- a/Project.toml
+++ b/Project.toml
@@ -13,7 +13,7 @@ StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 LorentzVectorHEPStaticArraysExt = "StaticArrays"
 
 [compat]
-LinearAlgebra = "1.11.0"
+LinearAlgebra = "1"
 StaticArrays = "1"
 julia = "^1.6"
 

--- a/src/LorentzVectorHEP.jl
+++ b/src/LorentzVectorHEP.jl
@@ -1,6 +1,6 @@
 module LorentzVectorHEP
 
-import Base: +, -, *, /, ==, isapprox, ≈
+using LinearAlgebra
 
 export LorentzVectorCyl, LorentzVector
 
@@ -40,40 +40,40 @@ LorentzVector(t::T, x::T, y::T, z::T) where {T <: Union{Integer, Rational, Irrat
 
 Inner product of 4-vectors, in the Minkowsky metric (+,-,-,-).
 """
-function dot(u::LorentzVector, v::LorentzVector)
+function LinearAlgebra.dot(u::LorentzVector, v::LorentzVector)
     @fastmath u.t*v.t - u.x*v.x - u.y*v.y - u.z*v.z
 end
 
 
-function +(u::LorentzVector, v::LorentzVector)
+function Base.:(+)(u::LorentzVector, v::LorentzVector)
     @fastmath LorentzVector(u.t + v.t, u.x + v.x, u.y + v.y, u.z + v.z)
 end
 
-function -(u::LorentzVector)
+function Base.:(-)(u::LorentzVector)
     @fastmath LorentzVector(-u.t, -u.x, -u.y, -u.z)
 end
 
-function -(u::LorentzVector, v::LorentzVector)
+function Base.:(-)(u::LorentzVector, v::LorentzVector)
     @fastmath u + (-v)
 end
 
-function *(λ::Number, u::LorentzVector)
+function Base.:(*)(λ::Number, u::LorentzVector)
     @fastmath LorentzVector(λ*u.t, λ*u.x, λ*u.y, λ*u.z)
 end
 
-function *(u::LorentzVector, λ::Number)
+function Base.:(*)(u::LorentzVector, λ::Number)
     @fastmath λ * u
 end
 
-function /(u::LorentzVector, λ::Number)
+function Base.:(/)(u::LorentzVector, λ::Number)
     @fastmath u * (one(λ) / λ)
 end
 
-function ==(u::LorentzVector, v::LorentzVector)
+function Base.:(==)(u::LorentzVector, v::LorentzVector)
     u.t == v.t && u.x == v.x && u.y == v.y && u.z == v.z
 end
 
-function isapprox(u::LorentzVector, v::LorentzVector;
+function Base.isapprox(u::LorentzVector, v::LorentzVector;
                   atol::Real=0,
                   rtol::Real=atol>0 ? 0 : √min(eps(typeof(u.x)), eps(typeof(v.x))))
 


### PR DESCRIPTION
This changes `dot` so that it is a method of the function from LinearAlgebra, analogous to how all the operations from `Base` already work.  This would make things a lot less confusing if you happen to be using both `LorentzVector` and arrays.

I've also taken the liberty to remove the `import` statements, which can be very dangerous because you can accidentally define a method for an external function.  This is consistent with existing code in `cylindrical.jl`.